### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
   coverage:
     if: contains(github.ref, 'main')


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/4](https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `test` job. This block will define the least privileges required for the job to execute. Based on the general recommendations, we will start with `contents: read` as the minimal permission. If the `test` job requires additional permissions, they can be added later after analyzing its specific requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
