### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -21,6 +21,8 @@ jobs:
     uses: ./.github/workflows/test.yml
   build:
     needs: test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/3](https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `build` job, explicitly setting `contents: read`. This ensures that the job has only the minimal permissions required to read the repository contents, without any write access. The `permissions` block will be added directly under the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
