### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@
 
 name: Test
 
+permissions:
+  contents: read
+
 on:
     workflow_call:
 


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/2](https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and does not appear to require write permissions. Therefore, we will set `contents: read` as the default permission. If any specific steps require additional permissions, they can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
