### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,6 +18,8 @@ env:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
   build:
     needs: test


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/5](https://github.com/piotr-ku/yaml-runner-go/security/code-scanning/5)

To fix the issue, add a `permissions` block to the `test` job in the workflow. Since the `test` job is likely running tests and does not appear to require write access, the permissions can be set to `contents: read` as a minimal starting point. This ensures that the job has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
